### PR TITLE
:wrench: Fix volume syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,16 +7,12 @@ services:
     ports:
       - "27020:27017"
     volumes:
-      - type: volume
-        source: ./mongo-logs
-        target: /data/db
+      - ./mongo-logs:/data/db
 
   messenger:
     build: ./arnaux
     volumes:
-      - type: volume
-        source: ./arnaux/logs
-        target: /arnaux/logs
+      - ./arnaux/logs:/arnaux/logs
 
   sandbox-service:
     depends_on:
@@ -55,9 +51,7 @@ services:
       - messenger
     build: ./front-service
     volumes:
-      - type: volume
-        source: ./front-service/logs
-        target: /front-end-service/logs
+      - ./front-service/logs:/front-end-service/logs
     environment:
       - DB_URI=mongodb://mongo-front-service/fe-db
       - ARNAUX_URL=ws://messenger:3000


### PR DESCRIPTION
Right, docker-compose v1.18 added volume long syntax validation (volume long syntax can apparently only be used together with a volumes section declaration)

The platform can't be built/run with this version because `docker-compose.yml` doesn't pass validation (fails on volume syntax).

This migrates our volume definitions to short syntax 🐱 

https://github.com/docker/compose/blob/master/CHANGELOG.md#1180-2017-12-15