### PR TITLE
Option run in dev mode using Hexfile.dev.yml

### DIFF
--- a/Hexfile.dev.yml
+++ b/Hexfile.dev.yml
@@ -44,7 +44,7 @@ services:
       - ARNAUX_URL=ws://messenger:3000
       - GUNSLINGERS=false
       - LOG_DBURI=mongodb://mongo-logs/qd-logs
-      - AUTH_CONFIG=config.secret.prod.json
+      - AUTH_CONFIG=config.secret.json
       - LOG_LEVEL=warn
       - LOG_CONSOLE=false
       - SOLUTION_SYNC_ONLY=true

--- a/Hexfile.dev.yml
+++ b/Hexfile.dev.yml
@@ -50,7 +50,7 @@ services:
       - SOLUTION_SYNC_ONLY=true
     ports:
       - "3000:3000"
-      - "3001:3001"
+      - "3010:3001"
   -
     name: sandbox-service:cssqd
     context: ./zandbak-service

--- a/Hexfile.dev.yml
+++ b/Hexfile.dev.yml
@@ -1,0 +1,101 @@
+services:
+  -
+    name: mongo-front-service
+    image: mongo
+    ports:
+      - "27019:27017"
+    volumes:
+      - mongo-front-service:/data/db
+  -
+    name: mongo-state
+    image: mongo
+    ports:
+      - "27018:27017"
+    volumes:
+      - mongo-state:/data/db
+  -
+    name: mongo-logs
+    image: mongo
+    ports:
+      - "27020:27017"
+    volumes:
+      - mongo-logs:/data/db
+  -
+    name: messenger
+    context: ./arnaux
+    environment:
+      - ARNAUX_LOG_LEVEL=Trace
+    ports:
+      - "3002:3000"
+    volumes:
+      - arnaux-logs:/arnaux/logs
+  -
+    name: state-service
+    context: ./redemption
+    environment:
+      - redemption_environment=prod
+  -
+    name: front-service
+    context: ./front-service
+    volumes:
+      - front-service-logs:/front-end-service/logs
+    environment:
+      - DB_URI=mongodb://mongo-front-service/fe-db
+      - ARNAUX_URL=ws://messenger:3000
+      - GUNSLINGERS=false
+      - LOG_DBURI=mongodb://mongo-logs/qd-logs
+      - AUTH_CONFIG=config.secret.prod.json
+      - LOG_LEVEL=warn
+      - LOG_CONSOLE=false
+      - SOLUTION_SYNC_ONLY=true
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+  -
+    name: sandbox-service:cssqd
+    context: ./zandbak-service
+    environment:
+      - remote_uri=ws://messenger:3000
+      - remote_identity=sandbox-service:cssqd
+      - zandbakConfig_sand=css
+      - zandbakConfig_validators=banned-chars
+      - zandbakConfig_backend=electron
+      - ELECTRON_ENABLE_LOGGING=1
+      - logLevel=+perf,+error,+info
+  -
+    name: sandbox-service:_qd
+    context: ./zandbak-service
+    environment:
+      - remote_uri=ws://messenger:3000
+      - remote_identity=sandbox-service:_qd
+      - zandbakConfig_sand=lodash
+      - zandbakConfig_validators=banned-chars
+      - zandbakConfig_backend=electron
+      - ELECTRON_ENABLE_LOGGING=1
+      - logLevel=+perf,+error,+info
+  -
+    name: sandbox-service:jsqd
+    context: ./zandbak-service
+    environment:
+      - remote_uri=ws://messenger:3000
+      - remote_identity=sandbox-service:jsqd
+      - zandbakConfig_sand=js/subworkers
+      - zandbakConfig_validators=acorn
+      - zandbakConfig_backend=electron
+      - ELECTRON_ENABLE_LOGGING=1
+      - logLevel=+perf,+error,+info
+      - zandbakConfig_workersCount=50
+      - zandbakConfig_subworkersCount=100
+  -
+    name: init-service
+    context: ./ignition
+
+messenger:
+  service: messenger
+  host: messenger
+  port: 3000
+
+init-sequence:
+  - mongo-front-service
+  - mongo-state
+  - mongo-logs

--- a/Hexfile.yml
+++ b/Hexfile.yml
@@ -50,7 +50,7 @@ services:
       - SOLUTION_SYNC_ONLY=true
     ports:
       - "3000:3000"
-      - "3001:3001"
+      - "3010:3001"
   -
     name: sandbox-service:cssqd
     context: ./zandbak-service

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,20 @@ IMAGE_NAME=qd-platform
 CONTAINER_NAME=qd-platform
 DOCKER_SOCKET=/var/run/docker.sock
 TIMEOUT_SECONDS=9999
+HEXFILE=./Hexfile.yml
+HEXFILE_DEV=./Hexfile.dev.yml
 
 all: build run
 
 build:
 	docker build -t $(IMAGE_NAME) .
 
-run:
+run: run-container
+
+run-dev:
+	@make HEXFILE=$(HEXFILE_DEV) run-container
+
+run-container:
 	docker run \
 	  --rm \
 	  --tty \
@@ -18,4 +25,5 @@ run:
 	  --stop-timeout=$(TIMEOUT_SECONDS) \
 	  --network hex-network \
 	  --mount type=bind,source=$(DOCKER_SOCKET),target=$(DOCKER_SOCKET) \
+	  --mount type=bind,source=$(abspath $(HEXFILE)),target=/opt/hex/Hexfile.yml \
 	  $(IMAGE_NAME)

--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ To build Docker image:
 
     $ make build
 
-To run platform:
+To run platform in development mode:
+
+    $ make run-dev
+
+To run platform in production mode:
 
     $ make run
 
 This will run platform container, which will be removed automatically after you stop it.
 You can use usual `docker stop` or `docker restart` to handle this container.
 
-By default, `$ make` will build and run the platform.
+By default, `$ make` will build and run the platform in production mode.


### PR DESCRIPTION
Now it's possible to supply custom `Hexfile.yml` when running platform container (using `bind` feature from Docker).

I've set up a new task, `make run-dev`, which will run container using `Hexfile.dev.yml`, so it's easier to have separate environments and tweak configuration.